### PR TITLE
Update metadata links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Juju prometheus libvirt exporter charm
 
-This charm provides the [Prometheus libvirt exporter](https://github.com/kumina/libvirt_exporter)
+This charm provides the [Prometheus libvirt exporter](https://github.com/Tinkoff/libvirt-exporter) (via the [snap](https://snapcraft.io/prometheus-libvirt-exporter)).
 
 ## Deployment
 

--- a/src/CONTRIBUTING.md
+++ b/src/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Developing
 
-Fork the [repository](https://code.launchpad.net/charm-prometheus-libvirt-exporter),
+Fork the [repository](https://github.com/canonical/charm-prometheus-libvirt-exporter/),
 and make some changes.
 
 ## Testing

--- a/src/layer.yaml
+++ b/src/layer.yaml
@@ -10,4 +10,4 @@ ignore: ['.*.swp' ]
 options:
     basic:
         use_venv: true
-repo: https://git.launchpad.net/prometheus-libvirt-exporter-charm
+repo: https://github.com/canonical/charm-prometheus-libvirt-exporter/

--- a/src/metadata.yaml
+++ b/src/metadata.yaml
@@ -6,6 +6,8 @@ description: |
   This exporter connects to any libvirt daemon and exports per-domain metrics
   related to CPU, memory, disk and network usage.
   By default, this exporter listens on TCP port 9177.
+issues: https://github.com/canonical/charm-prometheus-libvirt-exporter/issues
+source: https://github.com/canonical/charm-prometheus-libvirt-exporter
 tags:
   - monitoring
 subordinate: true


### PR DESCRIPTION
- link to the libvirt-exporter snap and the latest libvirt-exporter project it uses
- update launchpad links to github

Fixes #30 

Fixes #31 