### PR TITLE
Add support for arm64

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -56,10 +56,6 @@ jobs:
         with:
           provider: "lxd"
           juju-channel: ${{ matrix.juju-channel }}
-      - name: Install latest tox version
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install tox
       - name: Show juju information
         run: |
           juju version

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -26,17 +26,46 @@ jobs:
       working-directory: ./src
 
   func:
-    uses: canonical/bootstack-actions/.github/workflows/func.yaml@v2
     needs: lint-unit
+    name: functional tests
+    runs-on: ${{ matrix.architecture.runs-on }}
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
-        command: ["TEST_JUJU3=1 make functional"]  # TEST_JUJU3 needed due https://github.com/openstack-charmers/zaza/blob/b22c2eed4c322f1dfc14ffb2d31e0dd18c911a40/setup.py#L47 to support Juju3+
         juju-channel: ["3.4/stable"]
-    with:
-      command: ${{ matrix.command }}
-      juju-channel: ${{ matrix.juju-channel }}
-      nested-containers: false
-      provider: "lxd"
-      python-version: "3.10"
-      timeout-minutes: 120
+        architecture:
+          - runs-on: [ubuntu-latest]  # github hosted runners are amd64
+            model-constraints: ""
+            # Ubuntu_ARM64_4C_16G_01 is the github-hosted arm64 runner we have access to.
+            # We prefer the github runners because they are smaller machines and save resources.
+            # If we have issues with it, we can switch to the larger and more numerous self-hosted options:
+            # - runs-on: [self-hosted, jammy, ARM64]
+          - runs-on: [Ubuntu_ARM64_4C_16G_01]
+            model-constraints: arch=arm64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Setup Juju environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: "lxd"
+          juju-channel: ${{ matrix.juju-channel }}
+      - name: Install latest tox version
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
+      - name: Show juju information
+        run: |
+          juju version
+          juju controllers | grep Version -A 1 | awk '{print $9}'
+      - name: Run tests
+        run: "make functional"
+        env:
+          TEST_JUJU3: "1"  # https://github.com/openstack-charmers/zaza/pull/653
+          TEST_MODEL_CONSTRAINTS: ${{ matrix.architecture.model-constraints }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,20 +10,26 @@ jobs:
   check:
     uses: ./.github/workflows/check.yaml
     secrets: inherit
-
   release:
     needs: check
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [[ubuntu-latest], [Ubuntu_ARM64_4C_16G_01]]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Initialize lxd  # This should dropped once it's implemented on charming-actions itself. https://github.com/canonical/charming-actions/issues/140
-        uses: canonical/setup-lxd@v0.1.1
-      - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.4.0
+        # revision is latest main at time of writing; using because it contains a fix to https://github.com/canonical/setup-lxd/issues/19
+        uses: canonical/setup-lxd@2aa6f7caf7d1484298a64192f7f63a6684e648a4
+
+      - name: Pack and upload to charmhub
+        uses: canonical/charming-actions/upload-charm@2.6.2
         with:
+          charmcraft-channel: "2.x/stable"
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: "latest/edge"
-          # Note(rgildein): Right now we are not using destructive-mode, since our charmcraft.yaml is designed with a single build-on and the ability to run-on multiple bases. Running with destructive-mode would require aligning the base defined in this job with the one defined in charmcraft.yaml (build-on).
+          # Ensure the charm is built in an isolated environment and on the correct base in an lxd container.
           destructive-mode: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [[ubuntu-latest], [Ubuntu_ARM64_4C_16G_01]]
+        runs-on:
+          - ubuntu-latest
+          - Ubuntu_ARM64_4C_16G_01
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -21,15 +21,15 @@ bases:
           architectures:
               - amd64
     - build-on:
-￼        - name: ubuntu
-￼          channel: "22.04"
-￼          architectures: ["arm64"]
-￼      run-on:
-￼        - name: ubuntu
-￼          channel: "22.04"
-￼          architectures:
-￼              - arm64
-￼        - name: ubuntu
-￼          channel: "20.04"
-￼          architectures:
-￼              - arm64
+        - name: ubuntu
+          channel: "22.04"
+          architectures: ["arm64"]
+      run-on:
+        - name: ubuntu
+          channel: "22.04"
+          architectures:
+            - arm64
+        - name: ubuntu
+          channel: "20.04"
+          architectures:
+            - arm64

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -20,3 +20,16 @@ bases:
           channel: "20.04"
           architectures:
               - amd64
+    - build-on:
+￼        - name: ubuntu
+￼          channel: "22.04"
+￼          architectures: ["arm64"]
+￼      run-on:
+￼        - name: ubuntu
+￼          channel: "22.04"
+￼          architectures:
+￼              - arm64
+￼        - name: ubuntu
+￼          channel: "20.04"
+￼          architectures:
+￼              - arm64

--- a/src/tests/functional/tests/bundles/base.yaml
+++ b/src/tests/functional/tests/bundles/base.yaml
@@ -5,7 +5,7 @@ applications:
   prometheus-libvirt-exporter:
     charm: prometheus-libvirt-exporter
     options:
-      snap_channel: edge  # REMOVE ME AFTER TESTING
+      snap_channel: stable
 relations:
   - - ubuntu
     - prometheus-libvirt-exporter

--- a/src/tests/functional/tests/bundles/base.yaml
+++ b/src/tests/functional/tests/bundles/base.yaml
@@ -6,28 +6,6 @@ applications:
     charm: prometheus-libvirt-exporter
     options:
       snap_channel: stable
-  nrpe:
-    charm: nrpe
-    channel: latest/edge
-  prometheus:
-    charm: prometheus2
-    num_units: 1
-    series: focal
-  grafana:
-    charm: grafana
-    series: focal
-    channel: latest/edge # Temporary fix for 2023.10 release
-    num_units: 1
 relations:
   - - ubuntu
     - prometheus-libvirt-exporter
-  - - ubuntu:juju-info
-    - nrpe:general-info
-  - - prometheus-libvirt-exporter:nrpe-external-master
-    - nrpe:nrpe-external-master
-  - - prometheus-libvirt-exporter:scrape
-    - prometheus:target
-  - - prometheus:grafana-source
-    - grafana:grafana-source
-  - - prometheus-libvirt-exporter:dashboards
-    - grafana:dashboards

--- a/src/tests/functional/tests/bundles/base.yaml
+++ b/src/tests/functional/tests/bundles/base.yaml
@@ -5,7 +5,7 @@ applications:
   prometheus-libvirt-exporter:
     charm: prometheus-libvirt-exporter
     options:
-      snap_channel: stable
+      snap_channel: edge  # REMOVE ME AFTER TESTING
 relations:
   - - ubuntu
     - prometheus-libvirt-exporter

--- a/src/tests/functional/tests/test_prometheus_libvirt_exporter.py
+++ b/src/tests/functional/tests/test_prometheus_libvirt_exporter.py
@@ -17,7 +17,7 @@ TEST_TIMEOUT = 180
 DEFAULT_API_PORT = "9177"
 DEFAULT_API_URL = "/"
 PACKAGES = ("qemu-kvm", "libvirt-daemon", "libvirt-daemon-system", "virtinst")
-CIRROS_URL = "https://download.cirros-cloud.net/0.5.1/cirros-0.5.1-x86_64-disk.img"
+CIRROS_URL = "https://download.cirros-cloud.net/0.5.1/cirros-0.5.1-{}-disk.img"
 UBUNTU_SERIES_CODE = {
     "jammy": "22.04",
     "focal": "20.04",
@@ -101,6 +101,13 @@ class BasePrometheusLibvirtExporterTest(unittest.TestCase):
             )
 
         wget_cmd += "-q {} -O /var/lib/libvirt/images/cirros.img".format(CIRROS_URL)
+
+        # Get the arch of the VM
+        result = model.run_on_unit(cls.lead_unit_name, "uname -p")
+        code = result.get("Code")
+        if code != "0":
+            raise model.CommandRunFailed(cmd, result)
+        wget_cmd = wget_cmd.format(result.Stdout)
 
         # Install libvirt pkgs and bring up VM
         machine = model.get_machines(cls.application_name)[0]

--- a/src/tests/functional/tests/test_prometheus_libvirt_exporter.py
+++ b/src/tests/functional/tests/test_prometheus_libvirt_exporter.py
@@ -107,7 +107,7 @@ class BasePrometheusLibvirtExporterTest(unittest.TestCase):
         code = result.get("Code")
         if code != "0":
             raise model.CommandRunFailed(cmd, result)
-        wget_cmd = wget_cmd.format(result.Stdout)
+        wget_cmd = wget_cmd.format(result.get("Stdout").strip())
 
         # Install libvirt pkgs and bring up VM
         machine = model.get_machines(cls.application_name)[0]

--- a/src/tests/functional/tests/test_prometheus_libvirt_exporter.py
+++ b/src/tests/functional/tests/test_prometheus_libvirt_exporter.py
@@ -63,7 +63,7 @@ class BasePrometheusLibvirtExporterTest(unittest.TestCase):
         code = result.get("Code")
         if code != "0":
             raise model.CommandRunFailed("uname -p", result)
-        cls.arch = result.get("Stdout", "")
+        cls.arch = result.get("Stdout", "").strip()
 
         # Ubuntu_ARM64_4C_16G_01 github runner does not support kvm, so we skip
         # the setting up vm here. If the workflow changes, please visit this

--- a/src/tests/functional/tests/test_prometheus_libvirt_exporter.py
+++ b/src/tests/functional/tests/test_prometheus_libvirt_exporter.py
@@ -57,7 +57,6 @@ class BasePrometheusLibvirtExporterTest(unittest.TestCase):
         os.environ["ZAZA_FEATURE_BUG472"] = "1"
         cls.prometheus_libvirt_exporter_ip = model.get_app_ips(cls.application_name)[0]
         del os.environ["ZAZA_FEATURE_BUG472"]
-        cls.grafana_ip = model.get_app_ips("grafana")[0]
         if controller.get_cloud_type() == "lxd":
             # Get hostname
             logging.info("Getting hostname for unit {}".format(cls.lead_unit_name))

--- a/src/tests/functional/tests/tests.yaml
+++ b/src/tests/functional/tests/tests.yaml
@@ -9,10 +9,5 @@ dev_bundles:
 target_deploy_status:
   ubuntu:
     workload-status-message-prefix: ""
-  grafana:
-    workload-status-message-prefix: Started
-  nrpe:
-    workload-status: blocked
-    workload-status-message-prefix: Nagios server not configured or related
 tests:
   - tests.test_prometheus_libvirt_exporter.CharmOperationTest


### PR DESCRIPTION
- Update `charmcraft.yaml` to support arm64
- Update `check.yaml` to support arm64
- Update `release.yaml` to support arm64
- Removed LMA charms from the test bundle, they are not actively maintained, and can have issues.
- Conditionally set up vm with kvm in the functional test since `Ubuntu_ARM64_4C_16G_01` does not support kvm