### PR TITLE
Don't reconfigure scrape service and nrpe on every update-status hook

### DIFF
--- a/src/reactive/prometheus-libvirt-exporter.py
+++ b/src/reactive/prometheus-libvirt-exporter.py
@@ -86,7 +86,8 @@ def snap_channel_changed():
     remove_state("libvirt-exporter.started")
 
 
-@when_all("libvirt-exporter.started", "scrape.available")
+@when_all("libvirt-exporter.started", "endpoint.scrape.joined")
+@when_not("scrape.available")
 def configure_scrape_relation(scrape_service):
     """Connect prometheus to the the exporter for consumption."""
     scrape_service.configure(PORT_NUMBER)


### PR DESCRIPTION
The flags "libvirt-exporter.started" and "scrape.available" are always set after the scrape relation is successfully set up, which results in the method configure_scrape_relation being run on every update-status hook, which unsets the flag "libvirt-exporter.configured" and causes the update_nrpe_config method to be run, reconfiguring NRPE.

The solution is to re-arrange the flags so the method configure_scrape_relation is run only once. To achieve this, we change the flags to trigger when
"endpoint.scrape.joined" and when not "scape.available", which means it will run only once when the scrape relation is joined. At the end of the joined hook and upon
configuring the scrape relation , it will set the flag "scrape.available" and then the method
configure_scrape_relation will no longer be invoked.

The possibility of having to re-run the method has been considered but given the IP and PORT are hardcoded in the charm, it is assumed that those values will not need to be updated in the relation data.

Closes: #4
Closes: #56