### PR TITLE
Fix charm install hook by pinning setuptools

### DIFF
--- a/src/wheelhouse.txt
+++ b/src/wheelhouse.txt
@@ -1,0 +1,2 @@
+# https://github.com/pypa/setuptools/issues/4483
+setuptools==70.0.0


### PR DESCRIPTION
- pin setuptools to be able to install without errors
- Setuptools 71 will prefer installed dependencies over the vendored ones and this is currently breaking the instalation

More details can be found at:
- https://github.com/pypa/setuptools/issues/4483
- https://github.com/pypa/packaging-problems/issues/342