### PR TITLE
Workaround indirect build issue for reactive charm [1]

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,15 +1,14 @@
 type: charm
 parts:
   charm:
-    source: src
+    source: .
+    source-subdir: src
+    build-environment:
+    - PIP_CONSTRAINT: $CRAFT_PART_BUILD_WORK/constraints.txt
     plugin: reactive
     build-snaps: [charm]
     # This is tmp solution until #215 is not resolved. https://github.com/juju-solutions/layer-basic/issues/215
     build-packages: [python3-dev]
-    # Workaround for https://github.com/canonical/charmcraft/issues/2259
-    reactive-charm-build-arguments:
-      - --binary-wheels
-      - -v
 
 
 platforms:

--- a/src/constraints.txt
+++ b/src/constraints.txt
@@ -1,0 +1,2 @@
+# See https://github.com/canonical/charmcraft/issues/2259#issuecomment-2842766428
+setuptools_scm < 8.2.0


### PR DESCRIPTION

This is the way charmcraft team suggest us to do, and they will not add workaround in charmcraft level (like they did for other plugins) since reactive plugin is unofficially deprecated, and they don't maintain it as well (the build process is in `charm` snap)

Workaround indirect build issue for reactive charm [1].

[1]: https://github.com/canonical/solutions-engineering-automation/issues/218
