### PR TITLE
Allow manual dispatch of release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,7 @@
 name: Release to Edge
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
   release:


### PR DESCRIPTION
Update release.yaml to allow manual triggering of the release workflow. This is useful for re-triggering a failed
release workflow on the main branch.
